### PR TITLE
preかcodeの兄弟要素が絵文字に置換されないのを修正

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function replaceColons (node, emojis) {
   if (!node || !node.childNodes) { return }
   for (let i = node.childNodes.length - 1; i >= 0; i--) {
     const child = node.childNodes[i]
-    if (child.tagName === 'PRE' || child.tagName === 'CODE') { return }
+    if (child.tagName === 'PRE' || child.tagName === 'CODE') { continue }
     if (child.nodeType === 3) {
       const content = child.data.replace(
         /:(\w+):/ig,


### PR DESCRIPTION
### 問題

- **`pre`か`code`の兄弟要素が絵文字に置換されない**

#### 例

```markdown
:tada:hoge`foobar`
```

これを変換した

```html
<p>
  :tada:hoge
  <code>foobar</code>
</p>
```

こういう感じのHTMLで`:tada:`が 🎉 にならない

### 原因

- `pre`や`code`が出てきたときは中のコロンを置換しないよう処理を飛ばすところが、`return`で関数まるごと抜けてるせいで兄弟要素へのチェックも飛ばしてしまっている